### PR TITLE
Solve issue with unicode encoding

### DIFF
--- a/clipster
+++ b/clipster
@@ -769,7 +769,7 @@ def main():
         else:
             try:
                 # Ask server for clipboard history
-                print(client.client_output(client_action, args.number), end='')
+                print(client.client_output(client_action, args.number).encode('utf-8'), end='')
             except ClipsterError as exc:
                 logging.error(exc)
                 return 1


### PR DESCRIPTION
Got this error when using accentuated characters:

```
Traceback (most recent call last):
  File "/home/alx/bin/clipster", line 786, in <module>
    sys.exit(main())
  File "/home/alx/bin/clipster", line 772, in main
    print(client.client_output(client_action, args.number), end='')
UnicodeEncodeError: 'ascii' codec can't encode character u'\xea' in position 41: ordinal not in range(128)
```

Adding `encode('utf-8')` method helps to get rid of this error.

I'm not fluent in python, feel free to comment/refuse this issue.