### PR TITLE
handle SIGHUP and SIGPIPE for when X is stopped

### DIFF
--- a/clipster
+++ b/clipster
@@ -655,6 +655,8 @@ class Daemon(object):
         # Handle unix signals
         GLib.unix_signal_add(GLib.PRIORITY_HIGH, signal.SIGINT, self.exit)
         GLib.unix_signal_add(GLib.PRIORITY_HIGH, signal.SIGTERM, self.exit)
+        GLib.unix_signal_add(GLib.PRIORITY_HIGH, signal.SIGHUP, self.exit)
+        signal.signal(signal.SIGPIPE, self.exit)
 
         # Timeout for flushing history to disk
         # Do nothing if timeout is 0, or write_on_change is set in config


### PR DESCRIPTION
When the X server is closed (I don't use a display manager), clipster dies, but does not clean up its files. This change catches SIGHUP and SIGPIPE (the latter is the more important one) to allow clipster a chance to clean up the pid and socket files.