### PR TITLE
Optimizations

### DIFF
--- a/clipster
+++ b/clipster
@@ -204,6 +204,16 @@ class Daemon(object):
         self.update_history_file = False
         # Flag whether next clipboard change should be ignored
         self.ignore_next = {'PRIMARY': False, 'CLIPBOARD': False}
+        if self.config.get('clipster', 'filter_classes'):
+            self.filterd_classes = self.config.get('clipster', 'filter_classes').lower().split(',')
+            self.has_filter_list = True
+        else:
+            self.has_filter_list = False
+        if self.config.get('clipster', 'whitelist_classes'):
+            self.whitelist_classes = self.config.get('clipster', 'whitelist_classes').lower().split(',')
+            self.has_whitelist = True
+        else:
+            self.has_whitelist = False
 
     def keypress_handler(self, widget, event, board, tree_select):
         """Handle selection_widget keypress events."""
@@ -456,11 +466,11 @@ class Daemon(object):
             return
 
         # Only monitor owner-change events for apps with certain WM_CLASS values
-        if self.config.get('clipster', 'whitelist_classes'):
+        if self.has_whitelist:
             if not Wnck:
                 logging.error("'filter_classes' requires Wnck (libwnck3).")
                 return True
-            classes = self.config.get('clipster', 'whitelist_classes').lower().split(',')
+            classes = self.whitelist_classes
             logging.debug("Whitelist classes enabled for: %s", classes)
             screen = Wnck.Screen.get_default()
             screen.force_update()
@@ -472,11 +482,11 @@ class Daemon(object):
                 return True
 
         # Ignore owner-change events for apps with certain WM_CLASS values
-        if self.config.get('clipster', 'filter_classes'):
+        if self.has_filter_list:
             if not Wnck:
                 logging.error("'filter_classes' requires Wnck (libwnck3).")
                 return True
-            classes = self.config.get('clipster', 'filter_classes').lower().split(',')
+            classes = self.filterd_classes
             logging.debug("Filter classes enabled for: %s", classes)
             screen = Wnck.Screen.get_default()
             screen.force_update()

--- a/clipster
+++ b/clipster
@@ -455,6 +455,22 @@ class Daemon(object):
         if selection not in active:
             return
 
+        # Only monitor owner-change events for apps with certain WM_CLASS values
+        if self.config.get('clipster', 'whitelist_classes'):
+            if not Wnck:
+                logging.error("'filter_classes' requires Wnck (libwnck3).")
+                return True
+            classes = self.config.get('clipster', 'whitelist_classes').lower().split(',')
+            logging.debug("Whitelist classes enabled for: %s", classes)
+            screen = Wnck.Screen.get_default()
+            screen.force_update()
+            active_window = screen.get_active_window()
+            wm_class = active_window.get_class_group_name()
+            logging.debug("Active window class is %s", wm_class)
+            if wm_class.lower() not in classes:
+                logging.debug("Ignoring active window.")
+                return True
+
         # Ignore owner-change events for apps with certain WM_CLASS values
         if self.config.get('clipster', 'filter_classes'):
             if not Wnck:
@@ -794,7 +810,8 @@ def parse_config(args, data_dir, conf_dir):
                        "ignore_patterns": "no",  # Ignore selections which match regex patterns stored in data_dir/ignore_patterns (one per line).
                        "ignore_patterns_file": "%(conf_dir)s/ignore_patterns",  # patterns file for ignore_patterns
                        "pattern_as_selection": "no",  # Extracted pattern should replace current selection.
-                       "filter_classes": ""}  # Comma-separated list of WM_CLASS to identify apps from which to ignore owner-change events
+                       "filter_classes": "",  # Comma-separated list of WM_CLASS to identify apps from which to ignore owner-change events
+                       "whitelist_classes": ""}  # Comma-separated list of WM_CLASS to identify apps from which to not ignore owner-change events
 
     config = configparser.SafeConfigParser(config_defaults)
     config.add_section('clipster')

--- a/clipster
+++ b/clipster
@@ -204,8 +204,8 @@ class Daemon(object):
         self.update_history_file = False
         # Flag whether next clipboard change should be ignored
         self.ignore_next = {'PRIMARY': False, 'CLIPBOARD': False}
-        if self.config.get('clipster', 'filter_classes'):
-            self.filterd_classes = self.config.get('clipster', 'filter_classes').lower().split(',')
+        if self.config.get('clipster', 'blacklist_classes'):
+            self.filterd_classes = self.config.get('clipster', 'blacklist_classes').lower().split(',')
             self.has_filter_list = True
         else:
             self.has_filter_list = False
@@ -468,7 +468,7 @@ class Daemon(object):
         # Only monitor owner-change events for apps with certain WM_CLASS values
         if self.has_whitelist:
             if not Wnck:
-                logging.error("'filter_classes' requires Wnck (libwnck3).")
+                logging.error("'blacklist_classes' requires Wnck (libwnck3).")
                 return True
             classes = self.whitelist_classes
             logging.debug("Whitelist classes enabled for: %s", classes)
@@ -484,7 +484,7 @@ class Daemon(object):
         # Ignore owner-change events for apps with certain WM_CLASS values
         if self.has_filter_list:
             if not Wnck:
-                logging.error("'filter_classes' requires Wnck (libwnck3).")
+                logging.error("'blacklist_classes' requires Wnck (libwnck3).")
                 return True
             classes = self.filterd_classes
             logging.debug("Filter classes enabled for: %s", classes)
@@ -820,7 +820,7 @@ def parse_config(args, data_dir, conf_dir):
                        "ignore_patterns": "no",  # Ignore selections which match regex patterns stored in data_dir/ignore_patterns (one per line).
                        "ignore_patterns_file": "%(conf_dir)s/ignore_patterns",  # patterns file for ignore_patterns
                        "pattern_as_selection": "no",  # Extracted pattern should replace current selection.
-                       "filter_classes": "",  # Comma-separated list of WM_CLASS to identify apps from which to ignore owner-change events
+                       "blacklist_classes": "",  # Comma-separated list of WM_CLASS to identify apps from which to ignore owner-change events
                        "whitelist_classes": ""}  # Comma-separated list of WM_CLASS to identify apps from which to not ignore owner-change events
 
     config = configparser.SafeConfigParser(config_defaults)


### PR DESCRIPTION
Some small optimizations on top of the added whitelist feature.

We only parse the config option once, split it into the list, and set the booleans accordingly instead of parsing every time the clipboard is updated, which seems inefficient to me.

There are other places like that in the script, but for now I just wanted to get your opinion on it before doing anymore of those small optimizations. Perhaps there was a reason you did it that way? Just curious.