### PR TITLE
Fix index position output

### DIFF
--- a/clipster
+++ b/clipster
@@ -180,7 +180,7 @@ class Client(object):
             # Reassemble this, then join with delimiter
             json_data = json.loads(''.join(data))
             if self.args.position is not None:
-                json_data = json_data[self.args.position]
+                json_data = json_data[self.args.position:self.args.position+1]
             return self.args.delim.join(json_data)
 
 


### PR DESCRIPTION
Here is my quick fix for #90:

Fixes `clipster -o -N 0` outputting one character per line, instead of one entry per line (single entry).
